### PR TITLE
Forcer le HTTPS sur les nouvelles instances

### DIFF
--- a/instances/models.py
+++ b/instances/models.py
@@ -450,8 +450,9 @@ class Instance(BaseModel):
 
     def scalingo_create_app(self):
         sc = Scalingo(use_secnumcloud=bool(self.use_secnumcloud))
+        app_name = str(self.scalingo_application_name)
 
-        result = sc.app_create(app_name=str(self.scalingo_application_name))
+        result = sc.app_create(app_name=app_name)
 
         if "errors" in result.keys():
             return {
@@ -462,6 +463,13 @@ class Instance(BaseModel):
         else:
             self.status = "SCALINGO_APP_CREATED"
             self.save()
+
+            # Immediately force HTTPS on the newly created app
+            settings = {
+                "force_https": True,
+            }
+            sc.app_settings_update(app_name=app_name, settings=settings)
+
             return {
                 "status": "success",
                 "message": "Application Scalingo créée avec succès.",

--- a/instances/services/scalingo.py
+++ b/instances/services/scalingo.py
@@ -91,6 +91,28 @@ class Scalingo:
 
         return response.json()
 
+    def patch(self, query_path: str, json_data: dict) -> dict:
+        """
+        Makes a PATCH query to the endpoint and returns the result
+        """
+        self.check_session()
+
+        headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "user-agent": self.agent,
+            "Authorization": f"Bearer {self.bearer_token}",
+        }
+
+        response = requests.patch(
+            self.endpoint_url + query_path,
+            headers=headers,
+            json=json_data,
+            timeout=REQUEST_TIMEOUT,
+        )
+
+        return {"status_code": response.status_code}
+
     def post(
         self,
         query_path: str,
@@ -189,6 +211,11 @@ class Scalingo:
 
     def app_detail(self, app_name: str) -> dict:
         return self.get(f"apps/{app_name}")
+
+    def app_settings_update(self, app_name: str, settings: dict = {}):
+        json_data = {"app": settings}
+
+        return self.patch(f"apps/{app_name}", json_data=json_data)
 
     ## App / addon related methods
     def app_addon_detail(self, app_name: str, addon_id: str) -> dict:


### PR DESCRIPTION
## 🎯 Objectif
Les requêtes en HTTP devraient automatiquement être redirigées en HTTPS (recommandation de l'ANSSI)

## 🔍 Implémentation
- [x] Ajout des méthodes nécessaires dans le service `scalingo`
- [x] Appel de cette méthode au moment de la création de l'app.

