### PR TITLE
[bugfix] Correction d’un bug empêchant la suppression d'une configuration email

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,5 +164,4 @@ cython_debug/
 .vscode/
 
 # Projet specific
-.secrets_email.txt
-.secrets_storage.txt
+.secrets_*.txt

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,25 +1,8 @@
-"""
-URL configuration for config project.
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.1/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
-
 from django.conf import settings
 from django.contrib import admin
 from django.contrib.staticfiles.storage import staticfiles_storage
 from django.urls import include, path
-from django.views.generic import RedirectView
+from django.views.generic.base import RedirectView, TemplateView
 
 urlpatterns = [
     path(
@@ -27,6 +10,10 @@ urlpatterns = [
         RedirectView.as_view(
             url=staticfiles_storage.url("dsfr/dist/favicon/favicon.ico")
         ),
+    ),
+    path(
+        "robots.txt",
+        TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
     ),
     path("contacts/", include("contacts.urls")),
     path("instances/", include("instances.urls")),

--- a/core/templates/robots.txt
+++ b/core/templates/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /

--- a/instances/apps.py
+++ b/instances/apps.py
@@ -2,5 +2,5 @@ from django.apps import AppConfig
 
 
 class InstancesConfig(AppConfig):
-    default_auto_field = "django.db.models.BigAutoField"
+    default_auto_field = "django.db.models.BigAutoField"  # type: ignore
     name = "instances"

--- a/instances/templates/instances/emailconfig_confirm_delete.html
+++ b/instances/templates/instances/emailconfig_confirm_delete.html
@@ -1,0 +1,26 @@
+{% extends "core/base.html" %}
+{% load static i18n dsfr_tags %}
+
+{% block content %}
+  <h1>
+    Supprimer la configuration email « {{ object.default_from_email }} »
+  </h1>
+  <form method="post">
+    {% csrf_token %}
+    <p>
+      Voulez-vous vraiment supprimer la configuration email « {{ object.default_from_email }} » ?
+    </p>
+
+    {{ form }}
+    <div class="fr-input-group fr-my-4w">
+      <button type="submit" class="fr-btn" title="Confirmer">
+        Confirmer la suppression
+      </button>
+      <a href="{% url 'instances:emailconfig_list' %}"
+         class="fr-btn fr-btn--secondary"
+         title="Annuler">
+        Annuler
+      </a>
+    </div>
+  </form>
+{% endblock content %}


### PR DESCRIPTION
## 🎯 Objectif
Il manquait le template de confirmation de suppression.

## 🔍 Implémentation
- [x] Ajout du template manquant

## 🏕 Amélioration continue
- [x] Ajout du robots.txt
- [x] Généralisation d‘une entrée dans le `.gitignore`
