### PR TITLE
Gérer les collaborateurs des apps

### DIFF
--- a/instances/management/commands/add_collaborators.py
+++ b/instances/management/commands/add_collaborators.py
@@ -1,0 +1,57 @@
+from django.core.management.base import BaseCommand
+
+from instances.services.scalingo import Scalingo
+
+ALLOWED_ACTIONS = ["add", "list"]
+
+
+class Command(BaseCommand):
+    help = """Add a collaborator for all apps, or list collaborators.
+
+    CAUTION: it will act on all Scalingo apps for which the user has access.
+    Use it EXCLUSIVELY with an user who ONLY MANAGES SITES FACILES-RELATED APPS.
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--action",
+            type=str,
+            help="Type of action (add or list). Default: list.",
+            choices=ALLOWED_ACTIONS,
+            default="list",
+        )
+
+        parser.add_argument(
+            "--emails",
+            type=str,
+            help="Email of the collaborator(s) to add, separated by a comma ','.",
+        )
+
+    def handle(self, *args, **kwargs):  # NOSONAR
+        action = kwargs.get("action", "add")
+        emails = kwargs.get("emails", "")
+
+        if not emails:
+            raise ValueError("Missing parameter: emails.")
+
+        email_list = emails.split(",")
+
+        if action == "list":
+            self.stdout.write("List all collaborators for all apps.")
+        else:
+            print(f"List of email addresses to {action}: {email_list}")
+
+        for snc in [True, False]:
+            sc = Scalingo(use_secnumcloud=snc)
+
+            apps = sc.apps_list()
+
+            if action == "list":
+                for app in apps:
+                    collaborators = sc.app_collaborators_list(app)
+                    self.stdout.write(f"Collaborators for {app}: {collaborators}")
+            else:
+                for app in apps:
+                    for email in email_list:
+                        _invite = sc.app_collaborators_invite(app, email=email)
+                    self.stdout.write(f"Collaborators invited for {app}.")

--- a/instances/services/scalingo.py
+++ b/instances/services/scalingo.py
@@ -243,6 +243,13 @@ class Scalingo:
         else:
             return {"error": "error when removing addon"}
 
+    def app_collaborators_list(self, app_name: str):
+        return self.get(f"apps/{app_name}/collaborators")
+
+    def app_collaborators_invite(self, app_name: str, email: str):
+        json_data = {"collaborator": {"email": email}}
+        return self.post(f"apps/{app_name}/collaborators", json_data=json_data)
+
     def app_deployment_list(self, app_name: str):
         return self.get(f"apps/{app_name}/deployments")
 


### PR DESCRIPTION
## 🎯 Objectif
Script permettant de lister les collaborateurs des apps Scalingo et d'en inviter un nouveau (la suppression nécessite des droits auxquels le compte utilisateur actuel n'a pas accès et n'a donc pas été implémentée)
 
## 🔍 Implémentation
- [x] Ajout des fonctions nécessaires dans l'API
- [x] Création du script 

## ⚠️ Informations supplémentaires
ATTENTION : ce script agira sur toutes les applications Scalingo auxquelles l'utilisateur a accès.
Utilisez-le EXCLUSIVEMENT avec un utilisateur qui gère UNIQUEMENT les applications liées aux instances de Sites Faciles.

Lancer le script avec :

```
uv run python manage.py add_collaborators --action="list"
```
pour lister les utilisateurs de chaque instance

ou 

```
uv run python manage.py add_collaborators --action="add" --email="new.user@beta.gouv.fr"
```
pour en ajouter un.
