### PR TITLE
Correction d'une erreur dans la commande

### DIFF
--- a/instances/management/commands/scalingo_collaborators.py
+++ b/instances/management/commands/scalingo_collaborators.py
@@ -47,7 +47,9 @@ class Command(BaseCommand):
         for snc in snc_options:
             sc = Scalingo(use_secnumcloud=snc)
 
-            apps = instances.filter(use_secnumcloud=snc).values_list("name", flat=True)
+            apps = instances.filter(use_secnumcloud=snc).values_list(
+                "scalingo_application_name", flat=True
+            )
 
             if action == "list":
                 for app in apps:


### PR DESCRIPTION
## 🎯 Objectif
Utilisation du bon champ pour obtenir la liste des apps

## 🔍 Implémentation
- [x] Correction du nom du champ utilisé (nom de l'app scalingo au lieu de celui de l'instance)
