### PR TITLE
Ajout d'un script de transfert depuis les anciens S3

### DIFF
--- a/scripts/s3_transfer.sh
+++ b/scripts/s3_transfer.sh
@@ -11,20 +11,18 @@
 # opi → new storage
 # cf. https://help.ovhcloud.com/csm/fr-public-cloud-storage-s3-rclone?id=kb_article_view&sysparm_article=KB0047465 for config
 
-CLEVER="clever:storage-demo"
-OVH="ovh:suite-numerique-staging"
 
 echo "Please choose a source to sync:"
 echo "1) Clever Cloud"
 echo "2) OVH"
-read -p "Enter your choice [1 or 2]: " choice
+read -p "Enter your choice [1 or 2]: " CHOICE
 
-case "$choice" in
+case "${CHOICE}" in
     1)
-        STORAGE=${CLEVER}
+        STORAGE="clever:storage-demo"
         ;;
     2)
-        STORAGE=${OVH}
+        STORAGE="ovh:suite-numerique-staging"
         ;;
     *)
         echo "Invalid choice. Please run the script again."

--- a/scripts/s3_transfer.sh
+++ b/scripts/s3_transfer.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Retrieve data from the old Clever Cloud bucket and migrate it to new dedicated buckets
+# on an object storage belonging to the OPI
+
+# Can be launched again to sync the contents, as long as there are no duplicate locations
+
+# Profile names:
+# clever → old storage, hosted by Clever Cloud
+# ovh → old storage, hosted by OVH
+# opi → new storage
+# cf. https://help.ovhcloud.com/csm/fr-public-cloud-storage-s3-rclone?id=kb_article_view&sysparm_article=KB0047465 for config
+
+CLEVER="clever:storage-demo"
+OVH="ovh:suite-numerique-staging"
+
+echo "Please choose a source to sync:"
+echo "1) Clever Cloud"
+echo "2) OVH"
+read -p "Enter your choice [1 or 2]: " choice
+
+case "$choice" in
+    1)
+        STORAGE=${CLEVER}
+        ;;
+    2)
+        STORAGE=${OVH}
+        ;;
+    *)
+        echo "Invalid choice. Please run the script again."
+        exit 1
+        ;;
+esac
+
+for DIR in $(rclone lsf ${STORAGE} --dirs-only | sed 's:/$::'); do
+    echo "Processing $DIR"
+    rclone mkdir opi:$DIR
+    rclone sync ${STORAGE}/$DIR opi:$DIR/$DIR/ --progress
+done


### PR DESCRIPTION
## 🎯 Objectif
Crée des buckets sur le nouveau storage OPI en fonction des deux anciens buckets (un chez Clever Cloud, un chez OVH)

Ce fonctionnement passe de deux buckets partagés à un bucket par site.

## 🔍 Implémentation
- [x] Création du script

## ⚠️ Informations supplémentaires
Ce script nécessite d'installer et de configurer `rclone` avec trois profils nommés `clever`, `ovh` et `opi` (cf. [documentation d'OVH](https://help.ovhcloud.com/csm/fr-public-cloud-storage-s3-rclone?id=kb_article_view&sysparm_article=KB0047465))
