### PR TITLE
Ajout des configs d'email à l'admin Django

### DIFF
--- a/instances/admin.py
+++ b/instances/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
-from instances.models import Instance
+from instances.models import EmailConfig, Instance
 
 admin.site.register(Instance)
+admin.site.register(EmailConfig)


### PR DESCRIPTION
## 🎯 Objectif

Les configs d'email ne peuvent pas être administrées dans Django Admin, ceci corrige cela 
